### PR TITLE
fix: remove deprecated creature_template columns from SQL

### DIFF
--- a/data/sql/db-world/base/base_npc_emblem_transfer.sql
+++ b/data/sql/db-world/base/base_npc_emblem_transfer.sql
@@ -5,8 +5,7 @@ SET @Entry      := 100000,
 
 -- NPC
 DELETE FROM `creature_template` WHERE `entry`=@Entry;
-INSERT INTO `creature_template` (`entry`, `name`, `subname`, `IconName`, `gossip_menu_id`, `minlevel`, `maxlevel`, `faction`, `npcflag`, `speed_walk`, `speed_run`, `scale`, `rank`, `unit_class`, `unit_flags`, `type`, `type_flags`, `RegenHealth`, `flags_extra`, `ScriptName`) VALUES
-(@Entry, @Name, @Title, "Buy", 0, 80, 80, 35, 1, 1, 1.14286, 1, 0, 1, 2, 7, 138936390, 1, 16777216, "npc_emblem_transfer");
+INSERT INTO `creature_template` (`entry`, `name`, `subname`, `IconName`, `gossip_menu_id`, `minlevel`, `maxlevel`, `faction`, `npcflag`, `speed_walk`, `speed_run`, `rank`, `unit_class`, `unit_flags`, `type`, `type_flags`, `RegenHealth`, `flags_extra`, `ScriptName`) VALUES(@Entry, @Name, @Title, "Buy", 0, 80, 80, 35, 1, 1, 1.14286, 0, 1, 2, 7, 138936390, 1, 16777216, "npc_emblem_transfer");
 
 -- NPC MODEL
 DELETE FROM `creature_template_model` WHERE `CreatureID` = @Entry;


### PR DESCRIPTION
## Summary
- Removes `scale`, `mechanic_immune_mask`, and/or `spell_school_immune_mask` columns from `creature_template` INSERT/UPDATE statements
- These columns were removed from AzerothCore's `creature_template` table:
  - `scale` → moved to `creature_template_model.DisplayScale`
  - `mechanic_immune_mask`/`spell_school_immune_mask` → replaced by `CreatureImmunitiesId`

🤖 Generated with [Claude Code](https://claude.com/claude-code)